### PR TITLE
Update twocanoes xcreds to Xcreds release 2.2

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
@@ -17,7 +17,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-02-24T18:02:52Z</date>
+	<date>2023-02-27T13:50:21Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -539,7 +539,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>First Name OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_version</key>
+			<key>pfm_app_min</key>
 			<string>2.1</string>
 		</dict>
 		<dict>
@@ -557,7 +557,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Last Name OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_version</key>
+			<key>pfm_app_min</key>
 			<string>2.1</string>
 		</dict>
 		<dict>
@@ -575,7 +575,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Full Name OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_version</key>
+			<key>pfm_app_min</key>
 			<string>2.1</string>
 		</dict>
 		<dict>
@@ -593,7 +593,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Username OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_version</key>
+			<key>pfm_app_min</key>
 			<string>2.1</string>
 		</dict>
 	</array>

--- a/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
@@ -489,7 +489,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>idpHostName</string>
 			<key>pfm_title</key>
-			<string>idpHostName</string>
+			<string>IDP Host Name</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
@@ -520,7 +520,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>passwordElementID</string>
 			<key>pfm_title</key>
-			<string>passwordElementID</string>
+			<string>Password Element ID</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
@@ -530,7 +530,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Local DS to OIDC Mapping for First Name</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappingfirstname</string>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#map_firstname</string>
 			<key>pfm_name</key>
 			<string>map_firstname</string>
 			<key>pfm_note</key>
@@ -548,7 +548,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Local DS to OIDC Mapping for Last Name</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappinglastname</string>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#map_lastname</string>
 			<key>pfm_name</key>
 			<string>map_lastname</string>
 			<key>pfm_note</key>
@@ -566,7 +566,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Local DS to OIDC Mapping for Name</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappingfullname</string>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#map_fullname</string>
 			<key>pfm_name</key>
 			<string>map_fullname</string>
 			<key>pfm_note</key>
@@ -584,7 +584,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Local DS to OIDC Mapping for Name</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappinglusername</string>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#map_username</string>
 			<key>pfm_name</key>
 			<string>map_username</string>
 			<key>pfm_note</key>

--- a/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
@@ -17,7 +17,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-09-01T15:08:44Z</date>
+	<date>2023-02-24T18:02:52Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -539,6 +539,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>First Name OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
+			<key>pfm_app_version</key>
+			<string>2.1</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -555,6 +557,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Last Name OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
+			<key>pfm_app_version</key>
+			<string>2.1</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -571,6 +575,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Full Name OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
+			<key>pfm_app_version</key>
+			<string>2.1</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -587,6 +593,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Username OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
+			<key>pfm_app_version</key>
+			<string>2.1</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>
@@ -599,6 +607,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
@@ -489,7 +489,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>idpHostName</string>
 			<key>pfm_title</key>
-			<string>IDP Host Name</string>
+			<string>idpHostName</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
@@ -520,7 +520,71 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>passwordElementID</string>
 			<key>pfm_title</key>
-			<string>Password Element ID</string>
+			<string>passwordElementID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>given_name</string>
+			<key>pfm_description</key>
+			<string>Local DS to OIDC Mapping for First Name</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappingfirstname</string>
+			<key>pfm_name</key>
+			<string>map_firstname</string>
+			<key>pfm_note</key>
+			<string>Map firstName to OIDC claim</string>
+			<key>pfm_title</key>
+			<string>First Name OIDC Mapping</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>family_name</string>
+			<key>pfm_description</key>
+			<string>Local DS to OIDC Mapping for Last Name</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappinglastname</string>
+			<key>pfm_name</key>
+			<string>map_lastname</string>
+			<key>pfm_note</key>
+			<string>Map lastName to OIDC claim</string>
+			<key>pfm_title</key>
+			<string>Last Name OIDC Mapping</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>name</string>
+			<key>pfm_description</key>
+			<string>Local DS to OIDC Mapping for Name</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappingfullname</string>
+			<key>pfm_name</key>
+			<string>map_fullname</string>
+			<key>pfm_note</key>
+			<string>Map fullName to OIDC claim</string>
+			<key>pfm_title</key>
+			<string>Full Name OIDC Mapping</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>name</string>
+			<key>pfm_description</key>
+			<string>Local DS to OIDC Mapping for Name</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#oidcmappinglusername</string>
+			<key>pfm_name</key>
+			<string>map_username</string>
+			<key>pfm_note</key>
+			<string>Map Username to OIDC claim</string>
+			<key>pfm_title</key>
+			<string>Username OIDC Mapping</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>


### PR DESCRIPTION
Adds latest Xcreds release (2.2 - https://github.com/twocanoes/xcreds/releases/tag/realease_v2_2) manifest.