### PR TITLE
Allow configuring VPN.DNS for all VPN types

### DIFF
--- a/Manifests/ManifestsApple/com.apple.vpn.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.vpn.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-09-04T14:59:11Z</date>
+	<date>2023-10-11T01:30:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -3616,23 +3616,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>DNS settings for IKEv2 VPN types</string>
-			<key>pfm_exclude</key>
-			<array>
-				<dict>
-					<key>pfm_target_conditions</key>
-					<array>
-						<dict>
-							<key>pfm_n_range_list</key>
-							<array>
-								<string>IKEv2</string>
-							</array>
-							<key>pfm_target</key>
-							<string>VPNType</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
+			<string>DNS settings for the VPN</string>
 			<key>pfm_ios_min</key>
 			<string>10</string>
 			<key>pfm_macos_min</key>


### PR DESCRIPTION
Remove conditions that limited VPN.DNS to IKEv2 VPNs.

https://developer.apple.com/documentation/devicemanagement/vpn (retrieved on 2023-10-10) says that VPN.DNS is "A dictionary to use for all VPN types."