### PR TITLE
Correct VPN.DNS.SupplementalMatchDomainsNoSearch

### DIFF
--- a/Manifests/ManifestsApple/com.apple.vpn.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.vpn.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-10-11T01:30:00Z</date>
+	<date>2023-10-24T22:20:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -3747,6 +3747,8 @@
 					</dict>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Do not append the Supplemental Match Domains to the resolver's search domains.</string>
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_name</key>
@@ -3762,7 +3764,7 @@
 						<string>Do not append</string>
 					</array>
 					<key>pfm_title</key>
-					<string>Append Supplemental Match Domains to Search Domains</string>
+					<string>Do Not Search Supplemental Match Domains</string>
 					<key>pfm_type</key>
 					<string>integer</string>
 					<key>pfm_type_input</key>


### PR DESCRIPTION
https://developer.apple.com/documentation/devicemanagement/vpn/dns
(retrieved 2023-10-21) says,

> If 0, append the domains in the SupplementalMatchDomains list to the
> resolver’s list of search domains.
> Default: 0
> Possible Values: 0, 1

The `pfm_title` value "Append Supplemental Match Domains to Search
Domains" described this without the negative, which would have been
helpful except that the `pfm_type_input` type `boolean` creates a
checkbox control that follows the sense in the underlying manifest.