### PR TITLE
VPN segmented control: General/DNS/Proxies

### DIFF
--- a/Manifests/ManifestsApple/com.apple.vpn.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.vpn.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-10-25T07:21:23Z</date>
+	<date>2023-10-26T21:54:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -116,6 +116,45 @@
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
 			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>General</string>
+				<string>DNS</string>
+				<string>Proxies</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>General</key>
+				<array>
+					<string>AlwaysOn</string>
+					<string>IKEv2</string>
+					<string>IPSec</string>
+					<string>IPv4</string>
+					<string>PPP</string>
+					<string>TransparentProxy</string>
+					<string>UserDefinedName</string>
+					<string>VendorConfig</string>
+					<string>VPN</string>
+					<string>VPNSubType</string>
+					<string>VPNType</string>
+				</array>
+				<key>DNS</key>
+				<array>
+					<string>DNS</string>
+				</array>
+				<key>Proxies</key>
+				<array>
+					<string>Proxies</string>
+				</array>
+			</dict>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>

--- a/Manifests/ManifestsApple/com.apple.vpn.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.vpn.managed.plist
@@ -132,6 +132,10 @@
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
+				<key>DNS</key>
+				<array>
+					<string>DNS</string>
+				</array>
 				<key>General</key>
 				<array>
 					<string>AlwaysOn</string>
@@ -145,10 +149,6 @@
 					<string>VPN</string>
 					<string>VPNSubType</string>
 					<string>VPNType</string>
-				</array>
-				<key>DNS</key>
-				<array>
-					<string>DNS</string>
 				</array>
 				<key>Proxies</key>
 				<array>


### PR DESCRIPTION
These settings seem to be independent of VPN type, and Apple gave them their own pages in the macOS 14.0 system settings:

![image](https://github.com/DigiDNA/ProfileManifests/assets/35379118/837eda73-8a0e-4ec6-a643-70b9dbdff418)

