### PR TITLE
Add macOS 15.0 "Improve Search" preference

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.assistant.support.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.assistant.support.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-21T10:35:00Z</date>
+	<date>2024-09-28T18:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -144,6 +144,28 @@
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
+		<dict>
+			<key>pfm_description_reference</key>
+			<string>Help improve Search by allowing Apple to store your Safari, Siri, Spotlight, Lookup, and #images search queries.</string>
+			<key>pfm_macos_min</key>
+			<string>15.0</string>
+			<key>pfm_name</key>
+			<string>Search Queries Data Sharing Status</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Enabled</string>
+				<string>Disabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Improve Search</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -155,6 +177,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
This allows setting this preference which seems to be new in macOS Sequoia 15.0:

![image](https://github.com/user-attachments/assets/ebe33e20-6c92-45b6-a0e7-0b604723cc36)