### PR TITLE
Add new preferences for Claude Desktop application

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -169,6 +169,20 @@ During a profile replacement, the system updates payloads with the same `Payload
 		<dict>
 			<key>pfm_app_min</key>
 			<string>0.14.1</string>
+			<key>pfm_description</key>
+			<string>Restrict Claude for Desktop to a specific Organisation ID.</string>
+			<key>pfm_name</key>
+			<string>forceLoginOrgUUID</string>
+			<key>pfm_title</key>
+			<string>Force Claude Login UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>org_uuid</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>


### PR DESCRIPTION
first time submitting but i want to add the following key to restrict  claude desktop to an org id. its undocumented in claude docs, but works e.g 
<key>forceLoginOrgUUID</key>
<string>xxx</string>
please review as i may have made mistakes :)